### PR TITLE
Put types first in package exports

### DIFF
--- a/Taskfile
+++ b/Taskfile
@@ -14,8 +14,10 @@ buildMicrobundle5() {
   mv index.d.ts "$name.d.ts"
   mv "$name.js" "$name.mjs"
   cat ../package.json | jq --arg name "$name" '
-    .exports.".".default = "./\($name).mjs" | 
-    .exports.".".types = "./\($name).d.ts"
+    .exports."." = {
+      "types": "./\($name).d.ts",
+      "default": "./\($name).mjs"
+    }
   ' > package.json
   cd ..
   set +x

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "type": "module",
   "exports": {
     ".": {
-      "default": "./src/index.ts",
-      "types": "./src/index.ts"
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
     }
   },
   "repository": {


### PR DESCRIPTION
## Summary

- move the `types` condition before `default` in the source `package.json` export map
- update the release `Taskfile` rewrite so generated `dist/package.json` keeps the same order

## Verification

- `git diff --check`
- static check that source `package.json` has `types` before `default`
- static check that the `Taskfile` jq rewrite emits `types` before `default`
- packed the patched package with `npm pack --silent`
- installed the patched tarball into a clean TypeScript consumer with `typescript@5.9.3`, `@prisma/client@7`, `@prisma/client-runtime-utils@7`, and `graphql@16`; `npx tsc --noEmit -p tsconfig.json` passed with `moduleResolution: "NodeNext"`

Notes:

- I also tried `@arethetypeswrong/cli`, but its current run failed with `Cannot read properties of undefined (reading 'filename')`, so I am not using that as verification.
- Installing the repo's full dev dependency tree hit an upstream npm peer-resolution conflict unless `--legacy-peer-deps` was used, and the legacy install ran long enough that I stopped it. The package-shape change above is still covered by the source/generated metadata checks and clean consumer compile.

I used an AI coding assistant to prepare this patch.

Fixes #13
